### PR TITLE
fix: arreglar overflow entre "+20 horas" y "+40 charlistas" (#235)

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -32,11 +32,11 @@ export default function Home() {
       <Subtitle />
       <CountdownTimer />
       <CounterSubtitle />
-      <div className="flex gap-8">
-        <Button id="button-donate" href="/donar" variant="primary" classnames="md:py-3.5">
+      <div className="flex w-full gap-3 px-5 3xs:w-auto  3xs:gap-8 flex-col 3xs:flex-row">
+        <Button id="button-donate" href="/donar" variant="primary" classnames="py-3 md:py-3.5">
           Ir a donar
         </Button>
-        <Button id="button-info" href="agenda" variant="secondary" classnames="md:py-3.5">
+        <Button id="button-info" href="agenda" variant="secondary" classnames="py-3 md:py-3.5">
           Agenda
         </Button>
       </div>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -95,7 +95,7 @@ export function Navbar() {
               Quiénes somos + comunidades
             </Link>
           </div>
-          <div className="flex gap-3">
+          <div className="flex gap-3 pb-3 pl-3 border-b border-b-slate-700 lg:border-none">
             <Button
               href="/donar"
               variant="primary"

--- a/src/components/Subtitle/Subtitle.js
+++ b/src/components/Subtitle/Subtitle.js
@@ -6,7 +6,7 @@ export function Subtitle() {
       <span className="text-2xl xl:text-3xl text-primary relative">
         Streaming
         <svg
-          className="fill-primary absolute right-0 b top-9 w-100"
+          className="fill-primary absolute right-0 b top-8 w-100"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 212 21"
           aria-hidden="true"
@@ -14,7 +14,7 @@ export function Subtitle() {
           <path d="M187.6 20.5c-.2 0-.4 0-.6-.1-3.9-1-7.8-2.1-7.6-5.2.1-3.5 4.4-4.5 17.8-6.7.4-.1.8-.1 1.2-.2-3.7-.4-8.9-.9-16.2-1.4-55.5-4-141.3 1.6-178.9 5C1.8 12 .6 11 .5 9.7c-.1-1.4.9-2.6 2.3-2.8 37.8-3.5 123.9-9 179.7-5 9.7.7 16.6 1.3 21 2 4.8.7 7.9 1.3 8 4 .1 3.2-3.3 3.8-13.6 5.5-3.1.5-7.5 1.2-10.6 2 .3.1.5.1.8.2 1.3.3 2.2 1.7 1.8 3-.2 1.1-1.2 1.9-2.3 1.9z" />
         </svg>
       </span>
-      <span className="flex items-center gap-3">
+      <span className="flex items-center gap-3 mt-5 xxs:mt-0">
         <span className="text-4xl xl:text-6xl">+40 </span>
         <span className="text-2xl xl:text-3xl">charlistas</span>
       </span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,10 @@ module.exports = {
   ],
   theme: {
     extend: {
+      screens: {
+        'xxs': '568px',
+        '3xs': '400px',
+      },
       animation: {
         flip: "flip 1s cubic-bezier(0, 0, 0.2, 1) infinite",
       },


### PR DESCRIPTION
Se agregan DOS media query porque si no no funcionaba :v 

`screens: {
        'xxs': '568px',
        '3xs': '400px',
}`

![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/57545ac5-da6a-44a7-bf2b-2a56e6717a4f)
![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/5db6f2e3-cc8f-4ab8-97bf-6f35fa5a70eb)

También los usé para hacer botones más responsivos

![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/2c625073-7a3c-4b03-b183-dd2fc0e940d3)
![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/d435389d-aa93-4713-bd2f-bfe31e90d4a6)

![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/8a2fd23e-cb6a-479a-b97f-fb87aba0282a)

Añadí el borde que tiene el nav lg al movil y alejé un poco el botón de la esquina (añadí padding)


