### PR TITLE
fix: cambiar variant del botón de "Ver stream"

### DIFF
--- a/src/components/CountdownTimer.jsx
+++ b/src/components/CountdownTimer.jsx
@@ -60,7 +60,7 @@ export const CountdownTimer = () => {
         <Button
           href="https://www.twitch.tv/javascriptchile"
           target="_blank"
-          variant="primary"
+          variant="tertiary"
           classnames="bg-twitch text-white flex items-center gap-3 hover:bg-[#a675f4] hover:scale-105 duration-300 mt-10 mb-3 !text-3xl !px-10"
           id="twitch-mb-btn"
           setDefaultMinWidth={false}


### PR DESCRIPTION
Closes #255

El botón tenía el hover de los botones azules (primary) por el prop `variant` que se cambió a `tertiary` para que tenga el hover de los botones morados

![image](https://github.com/JSConfCL/TechTon-landing/assets/83615859/79a453ae-8210-465f-9d6a-baf2ad980704)
